### PR TITLE
Fix file selection on macos

### DIFF
--- a/packages/chonky/src/components/internal/ClickableWrapper-hooks.tsx
+++ b/packages/chonky/src/components/internal/ClickableWrapper-hooks.tsx
@@ -31,8 +31,9 @@ export const useClickHandler = (
         (event: React.MouseEvent) => {
             const mouseClickEvent: MouseClickEvent = {
                 altKey: event.altKey,
-                ctrlKey: event.ctrlKey,
+                ctrlKey: event.ctrlKey || event.metaKey,
                 shiftKey: event.shiftKey,
+
             };
 
             counter.current.clickCount++;


### PR DESCRIPTION
In MacOs, the command key is the meta key and is often used as ctrl.
Here ctrl+click in mac still opens the context menu. On the other hand,
cmd+click work as ctrl+click in other os.

Fix of https://github.com/TimboKZ/Chonky/issues/48