### PR TITLE
Revert "Import createTheme instead of createMuiTheme"

### DIFF
--- a/packages/chonky/src/components/external/FileBrowser.tsx
+++ b/packages/chonky/src/components/external/FileBrowser.tsx
@@ -1,5 +1,5 @@
 import {
-    createTheme,
+    createMuiTheme,
     ThemeProvider as MuiThemeProvider,
 } from '@material-ui/core/styles';
 import merge from 'deepmerge';
@@ -65,7 +65,7 @@ export const FileBrowser = React.forwardRef<
 
     const isMobileBreakpoint = useIsMobileBreakpoint();
     const theme = useMemo(() => {
-        const muiTheme = createTheme({
+        const muiTheme = createMuiTheme({
             palette: { type: darkMode ? 'dark' : 'light' },
         });
         const combinedTheme = merge(


### PR DESCRIPTION
Reverts TimboKZ/Chonky#103

Reverting as this breaks Chonky build:
```bash
✖ Failed to compile
(typescript) Error: /home/timbokz/Workspaces/personal/Chonky/packages/chonky/src/components/external/FileBrowser.tsx(2,5): semantic error TS2305: Module '"@material-ui/core/styles"' has no exported member 'createTheme'.
Error: /home/timbokz/Workspaces/personal/Chonky/packages/chonky/src/components/external/FileBrowser.tsx(2,5): semantic error TS2305: Module '"@material-ui/core/styles"' has no exported member 'createTheme'.
    at error (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup/dist/shared/node-entry.js:5400:30)
    at throwPluginError (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup/dist/shared/node-entry.js:11878:12)
    at Object.error (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup/dist/shared/node-entry.js:12912:24)
    at Object.error (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup/dist/shared/node-entry.js:12081:38)
    at RollupContext.error (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:17237:30)
    at /home/timbokz/Workspaces/personal/Chonky/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25033:23
    at arrayEach (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:545:11)
    at Function.forEach (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:9397:14)
    at printDiagnostics (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:25006:12)
    at Object.transform (/home/timbokz/Workspaces/personal/Chonky/node_modules/rollup-plugin-typescript2/dist/rollup-plugin-typescript2.cjs.js:29277:17)
```