### PR TITLE
Fix toolbar buttons overflowing on narrow screens (e.g. mobile)

### DIFF
--- a/packages/chonky/src/components/external/FileToolbar.tsx
+++ b/packages/chonky/src/components/external/FileToolbar.tsx
@@ -56,7 +56,7 @@ const useStyles = makeGlobalChonkyStyles(theme => ({
     },
     toolbarLeft: {
         paddingBottom: theme.margins.rootLayoutMargin,
-        flexWrap: 'nowrap',
+        flexWrap: 'wrap', // Ensure buttons do not overflow when the file manager is narrow.
         flexGrow: 10000,
         display: 'flex',
     },
@@ -65,7 +65,7 @@ const useStyles = makeGlobalChonkyStyles(theme => ({
     },
     toolbarRight: {
         paddingBottom: theme.margins.rootLayoutMargin,
-        flexWrap: 'nowrap',
+        flexWrap: 'wrap', // Ensure buttons do not overflow when the file manager is narrow.
         display: 'flex',
     },
 }));


### PR DESCRIPTION
Current look:

![image](https://user-images.githubusercontent.com/399535/213601205-57427c02-9be9-4783-be63-11abffa8013a.png)

Desired look, fixed with this PR:

![image](https://user-images.githubusercontent.com/399535/213601153-dcef6815-181f-4f5f-ac8c-92444a0df093.png)
